### PR TITLE
Update .zshrc

### DIFF
--- a/assets/.zshrc
+++ b/assets/.zshrc
@@ -28,3 +28,5 @@ alias l='ls -l'
 alias la='ls -a'
 alias lla='ls -la'
 alias lt='ls --tree'
+
+export XDG_DATA_DIRS=/usr/local/share:/usr/share:/var/lib/flatpak/exports/share:/home/nicola/.local/share/flatpak/exports/share


### PR DESCRIPTION
When attempting to **"Open a Folder"** from the VSCode menu, the application crashes. This issue appears to be caused by a missing `XDG_DATA_DIRS` environment variable, which prevents GTK from locating icon themes and loaders correctly.

To fix the issue, setting this environment variable resolves the crash:

```bash
export XDG_DATA_DIRS=/usr/local/share:/usr/share:/var/lib/flatpak/exports/share:/home/nicola/.local/share/flatpak/exports/share
```

### Error Output from `code --verbose`

```bash
(code:38921): Gtk-WARNING **: 22:49:37.887: Could not find the icon 'user-home-symbolic-ltr'. The 'hicolor' theme
was not found either, perhaps you need to install it.
You can get a copy from:
	http://icon-theme.freedesktop.org/releases
(code:38921): Gtk-WARNING **: 22:49:37.887: Could not load a pixbuf from /org/gtk/libgtk/icons/16x16/status/image-missing.png.
This may indicate that pixbuf loaders or the mime database could not be found.
**
Gtk:ERROR:../../../../gtk/gtkiconhelper.c:494:ensure_surface_for_gicon: assertion failed (error == NULL): Failed to load /org/gtk/libgtk/icons/16x16/status/image-missing.png: Unrecognized image file format (gdk-pixbuf-error-quark, 3)
Bail out! Gtk:ERROR:../../../../gtk/gtkiconhelper.c:494:ensure_surface_for_gicon: assertion failed (error == NULL): Failed to load /org/gtk/libgtk/icons/16x16/status/image-missing.png: Unrecognized image file format (gdk-pixbuf-error-quark, 3)
```

## Type of change

Please put an `x` in the boxes that apply:

- [ x] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that would cause existing functionality to not work as expected)
- [ ] **Documentation update** (non-breaking change; modified files are limited to the documentations)
- [ ] **Technical debt** (a code change that does not fix a bug or add a feature but makes something clearer for devs)
- [ ] **Other** (provide details below)

## Checklist

Please put an `x` in the boxes that apply:

- [ x] I have read the [CONTRIBUTING](https://github.com/JaKooLit/Ubuntu-Hyprland/blob/main/CONTRIBUTING.md) document.
- [x ] My code follows the code style of this project.
- [ x] My commit message follows the [commit guidelines](https://github.com/JaKooLit/Ubuntu-Hyprland/blob/main/CONTRIBUTING.md#git-commit-messages).
- [ ] My change requires a change to the documentation.
- [ ] I want to add something in Ubuntu-Hyprland wiki.
- [ ] I have added tests to cover my changes.
- [x ] I have tested my code locally and it works as expected.
- [ ] All new and existing tests passed.