### PR TITLE
25.10 ags fix

### DIFF
--- a/install-scripts/ags.sh
+++ b/install-scripts/ags.sh
@@ -95,11 +95,13 @@ sudo npm install --global typescript 2>&1 | tee -a "$LOG"
 # ags v1
 printf "${NOTE} Install and Compiling ${SKY_BLUE}Aylur's GTK shell $ags_tag${RESET}..\n"
 
-# Check if directory exists and remove it
-if [ -d "ags" ]; then
-    printf "${NOTE} Removing existing ags directory...\n"
-    rm -rf "ags"
-fi
+# Remove previous sources (both legacy "ags" and tagged "ags_v1.9.0")
+for SRC_DIR in "ags" "ags_v1.9.0"; do
+    if [ -d "$SRC_DIR" ]; then
+        printf "${NOTE} Removing existing %s directory...\\n" "$SRC_DIR"
+        rm -rf "$SRC_DIR"
+    fi
+done
 
 printf "\n%.0s" {1..1}
 printf "${INFO} Kindly Standby...cloning and compiling ${SKY_BLUE}Aylur's GTK shell $ags_tag${RESET}...\n"


### PR DESCRIPTION
# Pull Request

## Description
 
AGS v1.9.0 stopped working after recent OS updates    `ags.sh`  Now checks for required packages,  on re-install will remove the source directory and the installed binary in `/usr/local/bin/ags` 


fix(ags-deps): add GI introspection packages and GIRs (gobject-introspection, libgirepository1.0-dev, gir1.2-gtk-4.0, gir1.2-gtklayershell-0.1) plus build tools on Ubuntu

## Type of change

Please put an `x` in the boxes that apply:

- [X] **Bug fix** (non-breaking change which fixes an issue)

## Checklist
 
- [X] I have read the [CONTRIBUTING](https://github.com/JaKooLit/Ubuntu-Hyprland/blob/main/CONTRIBUTING.md) document.
- [X] My code follows the code style of this project.
- [X ] My commit message follows the [commit guidelines](https://github.com/JaKooLit/Ubuntu-Hyprland/blob/main/CONTRIBUTING.md#git-commit-messages).
- [X] I have tested my code locally and it works as expected.

 A user also verified the fix on her system.   Thanks @ninpwm  


## Screenshots

 
<img width="1706" height="946" alt="image" src="https://github.com/user-attachments/assets/c7a0de96-22f7-4967-ad94-984617e4dd3f" />
