### PR TITLE
fix: missing libjpeg-dev/libwebp-dev in hyprgraphics deps + README typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # 💌 KooL's Ubuntu Hyprland Install Script 💌
 
-## For Ubuntu 2.04 Resolute Raccoon ONLY!!!
+## For Ubuntu 26.04 Resolute Raccoon ONLY!!!
 
 <p align="center">
   <img src="https://raw.githubusercontent.com/JaKooLit/Hyprland-Dots/main/assets/latte.png" width="400" />

--- a/install-scripts/hyprgraphics.sh
+++ b/install-scripts/hyprgraphics.sh
@@ -5,6 +5,8 @@
 
 hyprgraphics=(
 	libmagic-dev
+	libjpeg-dev
+	libwebp-dev
 )
 
 #specific branch or release


### PR DESCRIPTION
## Summary

- Add `libjpeg-dev` and `libwebp-dev` to `hyprgraphics.sh` dependency list — without these, CMake fails with `required packages were not found: libjpeg, libwebp` when building hyprgraphics from source
- Fix typo in `README.md`: Ubuntu version `2.04` → `26.04`

## Test Plan

- [ ] Run `bash install-scripts/hyprgraphics.sh` on fresh Ubuntu 26.04 — CMake configure should pass without missing package errors
- [ ] Verify `README.md` line 5 shows `26.04`

🤖 Generated with [Claude Code](https://claude.com/claude-code)